### PR TITLE
ci(dependabot): increase open pull requests limit to 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     ignore:
       - dependency-name: 'vitest'
       - dependency-name: '@vitest/coverage-istanbul'
+    open-pull-requests-limit: 8
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
The previous limit was too restrictive for our dependency update needs. This change allows more concurrent dependency updates to be processed.