### PR TITLE
refactor: update import paths to use @/ prefix consistently

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -13,10 +13,11 @@
     },
     "baseUrl": "./",
     "paths": {
-      "@src/*": ["src/*"],
-      "@core/*": ["src/core/*"],
-      "@infra/*": ["src/infra/*"],
-      "@tests/*": ["tests/*"]
+      "@/src/*": ["src/*"],
+      "@/core/*": ["src/core/*"],
+      "@/modules/*": ["src/modules/*"],
+      "@/infra/*": ["src/core/infra/*"],
+      "@/tests/*": ["tests/*"]
     },
     "target": "es2022"
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -74,10 +74,11 @@ export default [
             // External packages
             [String.raw`^@?\w`],
             // Internal packages - usando tus paths del tsconfig
-            ['^@src(/.*|$)'],
-            ['^@core(/.*|$)'],
-            ['^@infra(/.*|$)'],
-            ['^@tests(/.*|$)'],
+            ['^@/src(/.*|$)'],
+            ['^@/core(/.*|$)'],
+            ['^@/modules(/.*|$)'],
+            ['^@/infra(/.*|$)'],
+            ['^@/tests(/.*|$)'],
             // Other imports
             ['^'],
             // Relative imports

--- a/src/core/infra/database/database.module.ts
+++ b/src/core/infra/database/database.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { envs } from '@src/config';
+import { envs } from '@/src/config';
 
 @Module({
   imports: [

--- a/src/core/infra/logger/logger.module.ts
+++ b/src/core/infra/logger/logger.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { LoggerModule as PinoLoggerModule } from 'nestjs-pino';
 
-import { envs } from '@src/config';
+import { envs } from '@/src/config';
 
 import { LoggerInterceptor } from './logger.interceptor';
 import { LoggerStrategy } from './logger.strategy';

--- a/src/core/redis/redis.module.ts
+++ b/src/core/redis/redis.module.ts
@@ -2,7 +2,7 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 import { redisStore } from 'cache-manager-redis-yet';
 
-import { envs } from '@src/config';
+import { envs } from '@/src/config';
 
 import { RedisService } from './redis.service';
 

--- a/tests/e2e/health.test.ts
+++ b/tests/e2e/health.test.ts
@@ -6,7 +6,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as nock from 'nock';
 import request from 'supertest';
 
-import { AppModule } from '@src/app.module';
+import { AppModule } from '@/src/app.module';
 
 describe('Health', () => {
   let app: NestFastifyApplication;

--- a/tests/unit/core/health/health.controller.test.ts
+++ b/tests/unit/core/health/health.controller.test.ts
@@ -1,8 +1,8 @@
 import { Logger } from 'nestjs-pino';
 
-import { HealthController } from '@src/core/health/health.controller';
+import { HealthController } from '@/src/core/health/health.controller';
 
-import { createMock, Mock } from '@tests/utils/mock';
+import { createMock, Mock } from '@/tests/utils/mock';
 
 describe('HealthController', () => {
   let controller: HealthController;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,11 @@
     "sourceMap": true,
     "target": "esnext",
     "paths": {
-      "@src/*": ["src/*"],
-      "@core/*": ["src/core/*"],
-      "@infra/*": ["src/infra/*"],
-      "@tests/*": ["tests/*"]
+      "@/src/*": ["src/*"],
+      "@/core/*": ["src/core/*"],
+      "@/modules/*": ["src/modules/*"],
+      "@/infra/*": ["src/core/infra/*"],
+      "@/tests/*": ["tests/*"]
     },
     "types": ["vitest/globals"]
   },


### PR DESCRIPTION
Update import paths across the codebase to use the @/ prefix instead of @src/ @core/ @infra/ @tests. This change aligns with the updated path configurations in .swcrc, tsconfig.json, and eslint.config.mjs, providing better consistency and clarity in module imports.

The modification includes:
1. Changing all @src/* imports to @/src/*
2. Updating path aliases in configuration files
3. Adjusting ESLint rules to match new import patterns